### PR TITLE
Unicode name support

### DIFF
--- a/lib/passport-azure-oauth/strategy.js
+++ b/lib/passport-azure-oauth/strategy.js
@@ -219,7 +219,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 	var profile = { provider : 'azureoauth' };
 	//try get user informations from the accessToken
 	try {
-		var stringUserInfo = new Buffer(accessToken.split('.')[1], 'base64').toString('ascii');
+		var stringUserInfo = new Buffer(accessToken.split('.')[1], 'base64').toString('utf-8');
 		profile.raw = stringUserInfo;
 		var objUserInfo = JSON.parse(stringUserInfo);
 		profile.rawObjet = objUserInfo;


### PR DESCRIPTION
If given_name or family_name is unicode, fail to JSON.parse.
