### PR TITLE
Make sure to attach params only if they exist

### DIFF
--- a/lib/passport-azure-oauth/strategy.js
+++ b/lib/passport-azure-oauth/strategy.js
@@ -23,7 +23,7 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'azureoauth';
   this._verify = verify;
-	
+
 	this._clientId = options.clientId;
 	this._clientSecret = options.clientSecret;
 	this._tenantId = options.tenantId;
@@ -53,7 +53,7 @@ function Strategy(options, verify) {
 	this._authURL = this._loginUrl + this._tenantId + this._authRelativeURL;
 	this._tokenURL = this._loginUrl + this._tenantId + this._tokenRelativeURL;
 	this._resource = options.resource;
-	
+
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
@@ -74,13 +74,13 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req != undefined && req.query && req.query.error) {
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
+
   // you can pass the appId and Secret in every round
 	if (options.clientId)
 		this._clientId = options.clientId;
@@ -88,19 +88,19 @@ Strategy.prototype.authenticate = function(req, options) {
 		this._clientSecret = options.clientSecret;
 	if (options.tenantId)
 		this._tenantId = options.tenantId;
-	
+
 	if (options.loginUrl) {
 		this._loginUrl = options.loginUrl;
 	} else if (!this._loginUrl) {
 		this._loginUrl = 'https://login.windows.net/';
 	}
-	
+
 	if (options.authRelativeURL) {
 		this._authRelativeURL = options.authRelativeURL;
 	} else if (!this._authRelativeURL) {
 		this._authRelativeURL = '/oauth2/authorize';
 	}
-	
+
 	if (options.tokenRelativeURL) {
 		this._tokenRelativeURL = options.tokenRelativeURL;
 	} else if (!this._tokenRelativeURL) {
@@ -112,20 +112,20 @@ Strategy.prototype.authenticate = function(req, options) {
   if (options.proxy) {
     this.proxy = options.proxy;
   }
-	
+
 	this._authURL = this._loginUrl + this._tenantId + this._authRelativeURL;
 	this._tokenURL = this._loginUrl + this._tenantId + this._tokenRelativeURL;
-	
+
 	if (options.resource)
 		this._resource = options.resource;
 	if (options.refreshToken)
 		this._refreshToken = options.refreshToken;
-		
+
 	if (!this._clientId) throw new Error('AzureOAuthStrategy requires a clientId.');
 	if (!this._clientSecret) throw new Error('AzureOAuthStrategy requires a clientSecret.');
 	if (!this._tenantId) throw new Error('AzureOAuthStrategy requires a tenant id.');
 	if (!this._resource) throw new Error('AzureOAuthStrategy requires a token URL.');
-  
+
   // check if there is a app token present
   if (typeof this._refreshToken != 'undefined') {
 		var redirectURL = undefined;
@@ -140,16 +140,16 @@ Strategy.prototype.authenticate = function(req, options) {
             if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
             if (!refreshToken)
               refreshToken = self._refreshToken;
-              
+
             self._loadUserProfile(accessToken, function(err, profile) {
               if (err) { return self.error(err); };
-            
+
               function verified(err, user, info) {
                 if (err) { return self.error(err); }
                 if (!user) { return self.fail(info); }
                 self.success(user, info);
               }
-              
+
               if (self._passReqToCallback) {
                 var arity = self._verify.length;
                 if (arity == 6) {
@@ -165,16 +165,15 @@ Strategy.prototype.authenticate = function(req, options) {
                   self._verify(accessToken, refreshToken, profile, verified);
                 }
               }
-            });  
+            });
         });
   } else if (req != undefined && req.query && req.query.code) {
-    this._oauth2 = new OAuth2(this._clientId, this._clientSecret, '', this._authURL, this._tokenURL, '', this.proxy);
-    var code = req.query.code;
-    var redirectURL = undefined;
-    if (this.redirectURL) {
-      var redirectURL = this.redirectURL + "?" + this.authorizationParamsForUrl(options);
-    }
-		
+
+    this._oauth2    = new OAuth2(this._clientId, this._clientSecret, '', this._authURL, this._tokenURL, '', this.proxy);
+    var code        = req.query.code;
+    var params4Url  = this.authorizationParamsForUrl(options);
+    var redirectURL = params4Url ? this.redirectURL + "?" + params4Url : this.redirectURL;
+
     // NOTE: The module oauth (0.9.5), which is a dependency, automatically adds
     //       a 'type=web_server' parameter to the percent-encoded data sent in
     //       the body of the access token request.  This appears to be an
@@ -184,16 +183,16 @@ Strategy.prototype.authenticate = function(req, options) {
     this._oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', resource: this._resource, redirect_uri : redirectURL},
       function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
-        
+
         self._loadUserProfile(accessToken, function(err, profile) {
           if (err) { return self.error(err); };
-          
+
           function verified(err, user, info) {
             if (err) { return self.error(err); }
             if (!user) { return self.fail(info); }
             self.success(user, info);
           }
-          
+
           if (self._passReqToCallback) {
             var arity = self._verify.length;
             if (arity == 6) {
@@ -226,10 +225,10 @@ Strategy.prototype.authenticate = function(req, options) {
     }
     var state = options.state;
     if (state) { params.state = state; }
-    
+
     var location = this._oauth2.getAuthorizeUrl(params);
     this.redirect(location);
-  } 
+  }
 }
 
 /**
@@ -249,7 +248,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 		profile.rawObject = objUserInfo;
 		profile.username = objUserInfo.unique_name;
 		profile.displayname = objUserInfo.given_name + ' ' + objUserInfo.family_name;
-	} catch(exception) { 
+	} catch(exception) {
 		console.log("Can't get profile informations!");
 	}
 	done(null, profile);
@@ -297,14 +296,14 @@ Strategy.prototype.authorizationParamsForUrl = function(options) {
  */
 Strategy.prototype._loadUserProfile = function(accessToken, done) {
   var self = this;
-  
+
   function loadIt() {
     return self.userProfile(accessToken, done);
   }
   function skipIt() {
     return done(null);
   }
-  
+
   if (typeof this._skipUserProfile == 'function' && this._skipUserProfile.length > 1) {
     // async
     this._skipUserProfile(accessToken, function(err, skip) {
@@ -322,5 +321,5 @@ Strategy.prototype._loadUserProfile = function(accessToken, done) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;


### PR DESCRIPTION
Trying to get access token ( getOAuthAccessToken ) with out any params it will extend callback url with "?" making 0365 to respond with a 400. 

This will only extend the url only if there are params pending to be extend in the callback url.
